### PR TITLE
Update recipe dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: d9a3c0dd1ca86728d3e235182683b4cf94cd53a867c288eaeca80ee781b2caff
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - uvicorn = uvicorn.main:main
@@ -23,7 +23,7 @@ requirements:
     - pip
   run:
     - python
-    - asgiref >=3.3.4
+    - asgiref >=3.4.0
     - click >=7.*
     - h11 >=0.8
     - typing-extensions  # [py<38]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
We encountered an a failed deploy of a product yesterday. Upon investigation, we found that the uvicorn conda-forge package was not correctly specifying its dependency on asgiref (the recipe says `asgiref >=3.3.4`, but uvicorn v0.15.0 actually requires `asgiref >=3.4.0`).

This PR re-generates the recipe using [grayskull](https://github.com/conda-incubator/grayskull). Please let me know if the new recipe is missing anything important that should be added back from the previous version.