### PR TITLE
update standard deps

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: cade07c403c397f9fe275492a48c1b869efd175d5d8a692df649e6e7e2ed8f4e
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: uvicorn
@@ -29,10 +29,9 @@ outputs:
         - pip
       run:
         - python
-        - asgiref >=3.4.0
         - click >=7.*
         - h11 >=0.8
-        - typing-extensions  # [py<38]
+        - typing_extensions  # [py<38]
 
     test:
       requires:
@@ -53,10 +52,12 @@ outputs:
       run:
         - {{ pin_subpackage('uvicorn', exact=True) }}
         - websockets >=10.0
-        - httptools >=0.2.0,<0.4.0
+        - httptools >=0.4.0
         - uvloop >=0.14.0,!=0.15.0,!=0.15.1  # [python_impl == "cpython" and not win]
         - colorama >=0.4  # [win]
-        - watchgod >=0.6
+        # TODO: deprecated, but maybe restore for e.g. pypy
+        # - watchgod >=0.6
+        - watchfiles >=0.13
         - python-dotenv >=0.13
         - PyYAML >=5.1
 
@@ -65,6 +66,10 @@ outputs:
         - pip
       commands:
         - pip check
+      imports:
+        - uvicorn.supervisors.watchfilesreload
+        # TODO: deprecated, but maybe restore for e.g. pypy
+        # uvicorn.supervisors.watchgodreload
 
 about:
   home: https://github.com/encode/uvicorn

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,9 +55,9 @@ outputs:
         - httptools >=0.4.0
         - uvloop >=0.14.0,!=0.15.0,!=0.15.1  # [python_impl == "cpython" and not win]
         - colorama >=0.4  # [win]
-        - watchfiles >=0.13  # [python_impl == "cpython"]
+        - watchfiles >=0.13  # [python_impl == "cpython" and not (aarch64 or ppc64le)]
         # TODO: deprecated, when watchfiles available for pypy
-        - watchgod >=0.6  # [python_impl == "pypy"]
+        - watchgod >=0.6  # [python_impl == "pypy" or (aarch64 or ppc64le)]
         - python-dotenv >=0.13
         - PyYAML >=5.1
 
@@ -67,9 +67,9 @@ outputs:
       commands:
         - pip check
       imports:
-        - uvicorn.supervisors.watchfilesreload  # [python_impl == "cpython"]
+        - uvicorn.supervisors.watchfilesreload  # [python_impl == "cpython" and not (aarch64 or ppc64le)]
         # TODO: deprecated, when watchfiles available for pypy
-        - uvicorn.supervisors.watchgodreload  # [python_impl == "pypy"]
+        - uvicorn.supervisors.watchgodreload  # [python_impl == "pypy" or (aarch64 or ppc64le)]
 
 about:
   home: https://github.com/encode/uvicorn

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,9 +55,9 @@ outputs:
         - httptools >=0.4.0
         - uvloop >=0.14.0,!=0.15.0,!=0.15.1  # [python_impl == "cpython" and not win]
         - colorama >=0.4  # [win]
-        # TODO: deprecated, but maybe restore for e.g. pypy
-        # - watchgod >=0.6
-        - watchfiles >=0.13
+        - watchfiles >=0.13  # [python_impl == "cpython"]
+        # TODO: deprecated, when watchfiles available for pypy
+        - watchgod >=0.6  # [python_impl == "pypy"]
         - python-dotenv >=0.13
         - PyYAML >=5.1
 
@@ -67,9 +67,9 @@ outputs:
       commands:
         - pip check
       imports:
-        - uvicorn.supervisors.watchfilesreload
-        # TODO: deprecated, but maybe restore for e.g. pypy
-        # uvicorn.supervisors.watchgodreload
+        - uvicorn.supervisors.watchfilesreload  # [python_impl == "cpython"]
+        # TODO: deprecated, when watchfiles available for pypy
+        - uvicorn.supervisors.watchgodreload  # [python_impl == "pypy"]
 
 about:
   home: https://github.com/encode/uvicorn


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- fixes #89
- sync deps with upstream
  - `run`
    - `asgiref` is no longer required
  - `standard`
    - `httptools` version was updated
    - `watchgod` implementation is deprecated...
      - ...but `watchfiles` is not yet available for pypy/aarch
        - https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3149